### PR TITLE
do not synchronize non-test methods

### DIFF
--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterTestResultSynchronizer.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterTestResultSynchronizer.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
+import org.testng.annotations.Test;
 
 /**
  * A helper class for Quality Center. Automatically handles the test run result synchronization by listening to the
@@ -193,6 +194,12 @@ public class QualityCenterTestResultSynchronizer extends AbstractCommonSynchroni
             if (syncType == SyncType.ANNOTATION) {
                 final Class<?> clazz = result.getTestClass().getRealClass();
                 final Method method = result.getMethod().getConstructorOrMethod().getMethod();
+
+                // do not synchronize non-test methods
+                if( ! method.isAnnotationPresent(Test.class) ) {
+                    return;
+                }
+
                 final String methodName = result.getMethod().getMethodName();
                 runId = QualityCenterSyncUtils.syncWithSyncType3(clazz, method, methodName, run, result);
             }

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterTestResultSynchronizer.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterTestResultSynchronizer.java
@@ -196,7 +196,7 @@ public class QualityCenterTestResultSynchronizer extends AbstractCommonSynchroni
                 final Method method = result.getMethod().getConstructorOrMethod().getMethod();
 
                 // do not synchronize non-test methods
-                if( ! method.isAnnotationPresent(Test.class) ) {
+                if( ! result.getMethod().isTest() ) {
                     return;
                 }
 


### PR DESCRIPTION
---
name: Pull Request
about: do not synchronize non-test methods
title: do not synchronize non-test methods
labels: enhancement
assignees: ''
---

# Description

This avids warnings for non-test methods, like for example "setUpClass": 

QualityCenterSyncUtils.getTestSetTestForAnnotation:265 - No method setUpClass found in Testset Root\...\int\Sprint 65: Sprint64 Inkrement TC_R2.1.1\Chrome ANT1: STB; Risklevel1. Could not synchronize with QC!

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
