### PR TITLE
Added sync with cucumber tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ gradle.properties
 /test-output/
 /qc11-connector/test-output/
 /cucumber-test/src/test/resources/qcconnection.properties
+/cucumber-test/test-report/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ gradle.properties
 /qc11-connector/test-report/
 /test-output/
 /qc11-connector/test-output/
+/cucumber-test/src/test/resources/qcconnection.properties

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ Feature: tests related to @Fails tag
     Then it fails
 ````
 
-The format is the same as the Java annotations but keep in mind that Cucumber tags are only strings. 
+The format is nearly the same as the Java annotations but keep in mind that Cucumber tags are only strings.
+
+Please use single `\`, not quoted `\\`!
 
 Instead of QC testname you can use the QC test id:
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,41 @@ set the `QCTestname` at each test method. The hpqc-connector will then lookup th
 name itself.
 
 ````java
-
 @QCTestset("\\Root\\My\\Full\\Path\\TestSet")
 public class CorrectClassAnnotationTest extends TesterraTest {
 
     @Test
     @QCTestname("Pass_Test_01")
+    public void testMethodPass() {
+        Assert.assertTrue(true);
+    }
+}
+````
+
+Instead of QC testname you can use the QC test id:
+
+````java
+@QCTestset("\\Root\\My\\Full\\Path\\TestSet")
+public class CorrectClassAnnotationTest extends TesterraTest {
+
+    @Test
+    @QCTestname(testId = 123)
+    public void testMethodPass() {
+        Assert.assertTrue(true);
+    }
+}
+````
+
+If you have added a QC testcase more than one to your testset, QC created a new test instance of the same testcase. Only the instance number is ascending by 1.
+
+````java
+@QCTestset("\\Root\\My\\Full\\Path\\TestSet")
+public class CorrectClassAnnotationTest extends TesterraTest {
+
+    // The second test instance of test 'Pass_Test_01' will sync.
+    // Default instanceCount is '1'
+    @Test
+    @QCTestname("Pass_Test_01", instanceCount = 2)
     public void testMethodPass() {
         Assert.assertTrue(true);
     }

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ Feature: tests related to @Fails tag
 
 The format is the same as the Java annotations but keep in mind that Cucumber tags are only strings. 
 
+Instead of QC testname you can use the QC test id:
+
+````gherkin
+@QCTestset("Root\Testerra\QCSyncResultTests\QcSyncResultTests")
+Feature: tests related to @Fails tag
+
+  @QCTestId("123")
+  Scenario: basic failing scenario
+    When the user does a step
+    Then it fails
+````
+
 ### Properties
 
 | Property                 | Default | Description                                                                                                                                            |

--- a/README.md
+++ b/README.md
@@ -112,20 +112,36 @@ public class CorrectClassAnnotationTest extends TesterraTest {
 }
 ````
 
+#### Cucumber tests
+
+You can use tags at your feature files to synchronize scenarios to QC.
+
+````gherkin
+@QCTestset("Root\Testerra\QCSyncResultTests\QcSyncResultTests")
+Feature: tests related to @Fails tag
+
+  @QCTestname("T01_QcSyncResultFailed")
+  Scenario: basic failing scenario
+    When the user does a step
+    Then it fails
+````
+
+The format is the same as the Java annotations but keep in mind that Cucumber tags are only strings. 
+
 ### Properties
 
-| Property                 | Default  | Description|
-|--------------------------|----------|-----------------------------------------------------|
-| qc.sync.active           | true     | Enables synchronization fo test results|
-| qc.connection.server     |          | URI of ALM / QC server|
-| qc.connection.user       |          | User to use for synchronization|
-| qc.connection.password   |          | Password of user used for synchronization|
-| qc.connection.domain}    |          | Domain of user to log in|
-| qc.connection.project    |          | Project of user to log in|
-| qc.version               | 12       | Version of Quality Center or ALM 11, 12 or higher|
-| qc.field.mapping.testrun |          | Customize field-value mapping for synchronize properties to the quality center testrun. Use the format key:value&#124;key2:value2 for multiple values. |
-| qc.upload.screenshots    | false    | Enable the upload of screenshots|
-| qc.upload.videos         | false    | Enable the upload of vides|
+| Property                 | Default | Description                                                                                                                                            |
+|--------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| qc.sync.active           | true    | Enables synchronization fo test results                                                                                                                |
+| qc.connection.server     |         | URI of ALM / QC server                                                                                                                                 |
+| qc.connection.user       |         | User to use for synchronization                                                                                                                        |
+| qc.connection.password   |         | Password of user used for synchronization                                                                                                              |
+| qc.connection.domain     |         | Domain of user to log in                                                                                                                               |
+| qc.connection.project    |         | Project of user to log in                                                                                                                              |
+| qc.version               | 12      | Version of Quality Center or ALM 11, 12 or higher                                                                                                      |
+| qc.field.mapping.testrun |         | Customize field-value mapping for synchronize properties to the quality center testrun. Use the format key:value&#124;key2:value2 for multiple values. |
+| qc.upload.screenshots    | false   | Enable the upload of screenshots                                                                                                                       |
+| qc.upload.videos         | false   | Enable the upload of vides                                                                                                                             |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Basically the synchronization will work by two explicit annotations that can be 
 
 #### Annotated class mode
 
-To enable synchronization you should add the annotation `QCTestset` to your class containing the test methods. The given value
-should match the complete path of Quality Center or Application Lifecycle Management test set, for an example see code snipped
+To enable synchronization you must add the annotation `QCTestset` to your class containing the test methods. The given value
+must match the complete path of Quality Center or Application Lifecycle Management test set, for an example see code snipped
 below:
 
 ```java
@@ -91,7 +91,7 @@ public class CorrectClassAnnotationTest extends TesterraTest {
 ```
 
 This little snippet will search for a test set called `\\Root\\My\\Full\\Path\\TestSet`. If found, the method name will be extracted
-and searched as test name in QC/ALM. If found, the result will be synchronized to this test case.
+and searched as test name in QC/ALM and the result will be synchronized to this test case.
 
 #### Annotated test method mode
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ ext {
     if (System.properties.containsKey('moduleVersion')) {
         moduleVersion = System.getProperty('moduleVersion')
     }
+
+    // Supported Cucumber version
+    cucumberVersion = '5.6.0'
 }
 
 allprojects {

--- a/cucumber-test/build.gradle
+++ b/cucumber-test/build.gradle
@@ -1,5 +1,4 @@
 ext {
-    cucumberVersion = '5.6.0'
     testerraTestVersion = '1.12'
 }
 
@@ -8,6 +7,9 @@ dependencies {
     implementation 'io.testerra:driver-ui-desktop:' + testerraTestVersion
     implementation 'io.testerra:report-ng:' + testerraTestVersion
     implementation 'io.testerra:cucumber-connector:1.1'
+
+    implementation project(':qc-restclient')
+    implementation project(':qc11-connector:')
 
     implementation 'io.cucumber:cucumber-java:' + cucumberVersion
     implementation('io.cucumber:cucumber-testng:' + cucumberVersion) {

--- a/cucumber-test/build.gradle
+++ b/cucumber-test/build.gradle
@@ -1,0 +1,31 @@
+ext {
+    cucumberVersion = '5.6.0'
+    testerraTestVersion = '1.12'
+}
+
+dependencies {
+
+    implementation 'io.testerra:driver-ui-desktop:' + testerraTestVersion
+    implementation 'io.testerra:report-ng:' + testerraTestVersion
+    implementation 'io.testerra:cucumber-connector:1.1'
+
+    implementation 'io.cucumber:cucumber-java:' + cucumberVersion
+    implementation('io.cucumber:cucumber-testng:' + cucumberVersion) {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+}
+
+test {
+    useTestNG() {}
+
+    testLogging {
+        outputs.upToDateWhen { false }
+        showStandardStreams = true
+    }
+
+    options {
+        systemProperties(System.getProperties())
+    }
+
+    ignoreFailures = true
+}

--- a/cucumber-test/src/main/java/io/testerra/plugins/hpqcconn/cucumber/pages/GoogleSearchPage.java
+++ b/cucumber-test/src/main/java/io/testerra/plugins/hpqcconn/cucumber/pages/GoogleSearchPage.java
@@ -1,0 +1,22 @@
+package io.testerra.plugins.hpqcconn.cucumber.pages;
+
+import eu.tsystems.mms.tic.testframework.pageobjects.GuiElement;
+import eu.tsystems.mms.tic.testframework.pageobjects.Page;
+import eu.tsystems.mms.tic.testframework.pageobjects.factory.PageFactory;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class GoogleSearchPage extends Page {
+
+    protected GuiElement inputSearch = new GuiElement(getWebDriver(), By.xpath("//input[@title='Suche']"));
+
+    public GoogleSearchPage(WebDriver driver) {
+        super(driver);
+    }
+
+    public GoogleSearchResultPage searchTerm(String term) {
+        inputSearch.sendKeys(term);
+        inputSearch.submit();
+        return PageFactory.create(GoogleSearchResultPage.class, getWebDriver());
+    }
+}

--- a/cucumber-test/src/main/java/io/testerra/plugins/hpqcconn/cucumber/pages/GoogleSearchResultPage.java
+++ b/cucumber-test/src/main/java/io/testerra/plugins/hpqcconn/cucumber/pages/GoogleSearchResultPage.java
@@ -1,0 +1,22 @@
+package io.testerra.plugins.hpqcconn.cucumber.pages;
+
+import eu.tsystems.mms.tic.testframework.pageobjects.GuiElement;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class GoogleSearchResultPage extends GoogleSearchPage {
+
+    GuiElement resultElements = new GuiElement(getWebDriver(), By.cssSelector("#rso .g"));
+
+    public GoogleSearchResultPage(WebDriver driver) {
+        super(driver);
+    }
+
+    public boolean containsResult(String resultText) {
+        boolean resultFound = false;
+        for (GuiElement guiElement : resultElements.getList()) {
+            resultFound = resultFound || guiElement.getSubElement(By.cssSelector("a h3")).getText().toLowerCase().contains(resultText.toLowerCase());
+        }
+        return resultFound;
+    }
+}

--- a/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/steps/StepDefinitions.java
+++ b/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/steps/StepDefinitions.java
@@ -2,6 +2,7 @@ package io.testerra.plugins.hpqcconn.cucumber.steps;
 
 import eu.tsystems.mms.tic.testframework.annotations.Fails;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.testng.Assert;
@@ -20,6 +21,7 @@ public class StepDefinitions implements Loggable {
 
     @Then("it fails")
     public void itFails() {
+        TimerUtils.sleep(2_000, "Waiter to get test duration.");
         Assert.fail("This step is supposed to fail");
     }
 

--- a/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/steps/StepDefinitions.java
+++ b/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/steps/StepDefinitions.java
@@ -1,0 +1,43 @@
+package io.testerra.plugins.hpqcconn.cucumber.steps;
+
+import eu.tsystems.mms.tic.testframework.annotations.Fails;
+import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.testng.Assert;
+
+public class StepDefinitions implements Loggable {
+
+    @When("the user searches for {string}")
+    public void iSearchFor(String searchInput) {
+        log().info("Search something " + searchInput);
+    }
+
+    @Then("an entry for {string} is shown")
+    public void anEntryForIsShown(String resultEntryText) {
+        log().info("Assert search result to contain " + resultEntryText);
+    }
+
+    @Then("it fails")
+    public void itFails() {
+        Assert.fail("This step is supposed to fail");
+    }
+
+    @When("the user does a step")
+    public void theUserDoesAStep() {
+
+    }
+
+    @Fails(description = "This is supposed to fail", ticketString = "TESTID-12345")
+    @Then("it fails expectedly")
+    public void itFailsExpectedly() {
+        Assert.fail("This step is supposed to fail with an expected fail");
+    }
+
+
+    @Fails(description = "This is supposed to work", ticketString = "TESTID-12345")
+    @Then("it doesn't fails unexpectedly")
+    public void itDoesnTFailsUnexpectedly() {
+        Assert.assertTrue(true);
+    }
+}

--- a/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/tests/RunTesterraCucumberTest.java
+++ b/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/tests/RunTesterraCucumberTest.java
@@ -1,15 +1,27 @@
 package io.testerra.plugins.hpqcconn.cucumber.tests;
 
 import eu.tsystems.mms.tic.testframework.report.TesterraListener;
+import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;
 import io.cucumber.testng.AbstractTestNGCucumberTests;
 import io.cucumber.testng.CucumberOptions;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 
 @Listeners(TesterraListener.class)
+@QCTestset("Root\\Testerra\\QCSyncResultTests\\QcSyncResultTests")
 @CucumberOptions(
         plugin = {"eu.tsystems.mms.tic.testerra.plugins.cucumber.TesterraReportPlugin"},
         features = "src/test/resources/features/",
-        glue = {"io.testerra.plugins.hpqcconn.cucumber.steps"}
+        glue = {"io.testerra.plugins.hpqcconn.cucumber.steps"
+                ,"eu.tsystems.mms.tic.testerra.plugins.cucumber"
+        }
 )
 public class RunTesterraCucumberTest extends AbstractTestNGCucumberTests {
+
+    @Override
+    @DataProvider(parallel = true)
+    public Object[][] scenarios() {
+        return super.scenarios();
+    }
+
 }

--- a/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/tests/RunTesterraCucumberTest.java
+++ b/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/tests/RunTesterraCucumberTest.java
@@ -1,0 +1,15 @@
+package io.testerra.plugins.hpqcconn.cucumber.tests;
+
+import eu.tsystems.mms.tic.testframework.report.TesterraListener;
+import io.cucumber.testng.AbstractTestNGCucumberTests;
+import io.cucumber.testng.CucumberOptions;
+import org.testng.annotations.Listeners;
+
+@Listeners(TesterraListener.class)
+@CucumberOptions(
+        plugin = {"eu.tsystems.mms.tic.testerra.plugins.cucumber.TesterraReportPlugin"},
+        features = "src/test/resources/features/",
+        glue = {"io.testerra.plugins.hpqcconn.cucumber.steps"}
+)
+public class RunTesterraCucumberTest extends AbstractTestNGCucumberTests {
+}

--- a/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/tests/RunTesterraCucumberTest.java
+++ b/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/tests/RunTesterraCucumberTest.java
@@ -1,14 +1,12 @@
 package io.testerra.plugins.hpqcconn.cucumber.tests;
 
 import eu.tsystems.mms.tic.testframework.report.TesterraListener;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;
 import io.cucumber.testng.AbstractTestNGCucumberTests;
 import io.cucumber.testng.CucumberOptions;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 
 @Listeners(TesterraListener.class)
-//@QCTestset("Root\\Testerra\\QCSyncResultTests\\QcSyncResultTests")
 @CucumberOptions(
         plugin = {"eu.tsystems.mms.tic.testerra.plugins.cucumber.TesterraReportPlugin"},
         features = "src/test/resources/features/",

--- a/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/tests/RunTesterraCucumberTest.java
+++ b/cucumber-test/src/test/java/io/testerra/plugins/hpqcconn/cucumber/tests/RunTesterraCucumberTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 
 @Listeners(TesterraListener.class)
-@QCTestset("Root\\Testerra\\QCSyncResultTests\\QcSyncResultTests")
+//@QCTestset("Root\\Testerra\\QCSyncResultTests\\QcSyncResultTests")
 @CucumberOptions(
         plugin = {"eu.tsystems.mms.tic.testerra.plugins.cucumber.TesterraReportPlugin"},
         features = "src/test/resources/features/",

--- a/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
+++ b/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
@@ -1,3 +1,4 @@
+@QCTestset("Root\Testerra\QCSyncResultTests\QcSyncResultTests")
 Feature: tests related to @Fails tag
 
   @QCTestname("T01_QcSyncResultFailed")
@@ -5,9 +6,10 @@ Feature: tests related to @Fails tag
     When the user does a step
     Then it fails
 
-#  Scenario: T02_QcSyncResultPassed
-#    When the user does a step
-#    Then it fails
+  @QCTestname("T02_QcSyncResultPassed")
+  Scenario: T02_QcSyncResultPassed
+    When the user does a step
+    Then it fails
 
 #  @Fails
 #  Scenario: failing scenario with fails tag and no fails on step

--- a/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
+++ b/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
@@ -1,23 +1,28 @@
 Feature: tests related to @Fails tag
 
+  @QCTestname("T01_QcSyncResultFailed")
   Scenario: basic failing scenario
     When the user does a step
     Then it fails
 
-  @Fails
-  Scenario: failing scenario with fails tag and no fails on step
-    Then it fails
+#  Scenario: T02_QcSyncResultPassed
+#    When the user does a step
+#    Then it fails
 
-  @Fails
-  Scenario: expected failing search with Fails Annotation
-    When the user does a step
-    Then it fails
-
-  Scenario: scenario with fails on failing step implementation
-    When the user does a step
-    Then it fails expectedly
-
-  @Fails
-  Scenario: successful expected failing search
-    When the user does a step
-    Then it doesn't fails unexpectedly
+#  @Fails
+#  Scenario: failing scenario with fails tag and no fails on step
+#    Then it fails
+#
+#  @Fails
+#  Scenario: expected failing search with Fails Annotation
+#    When the user does a step
+#    Then it fails
+#
+#  Scenario: scenario with fails on failing step implementation
+#    When the user does a step
+#    Then it fails expectedly
+#
+#  @Fails
+#  Scenario: successful expected failing search
+#    When the user does a step
+#    Then it doesn't fails unexpectedly

--- a/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
+++ b/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
@@ -1,0 +1,23 @@
+Feature: tests related to @Fails tag
+
+  Scenario: basic failing scenario
+    When the user does a step
+    Then it fails
+
+  @Fails
+  Scenario: failing scenario with fails tag and no fails on step
+    Then it fails
+
+  @Fails
+  Scenario: expected failing search with Fails Annotation
+    When the user does a step
+    Then it fails
+
+  Scenario: scenario with fails on failing step implementation
+    When the user does a step
+    Then it fails expectedly
+
+  @Fails
+  Scenario: successful expected failing search
+    When the user does a step
+    Then it doesn't fails unexpectedly

--- a/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
+++ b/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
@@ -9,7 +9,12 @@ Feature: tests related to @Fails tag
   @QCTestname("T02_QcSyncResultPassed")
   Scenario: T02_QcSyncResultPassed
     When the user does a step
-    Then it fails
+    Then it doesn't fails unexpectedly
+
+  @QCTestname("T04QcSyncResultPassedSpaces")
+  Scenario: T04_QcSyncResultPassedSpaces
+    When the user does a step
+    Then it doesn't fails unexpectedly
 
 #  @Fails
 #  Scenario: failing scenario with fails tag and no fails on step

--- a/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
+++ b/cucumber-test/src/test/resources/features/ExpectedFailedTests.feature
@@ -11,7 +11,7 @@ Feature: tests related to @Fails tag
     When the user does a step
     Then it doesn't fails unexpectedly
 
-  @QCTestname("T04QcSyncResultPassedSpaces")
+  @QCTestId("2264")
   Scenario: T04_QcSyncResultPassedSpaces
     When the user does a step
     Then it doesn't fails unexpectedly

--- a/cucumber-test/src/test/resources/features/GoogleSearch.feature
+++ b/cucumber-test/src/test/resources/features/GoogleSearch.feature
@@ -1,15 +1,15 @@
 Feature: google search
 
-  Scenario: search something on google
-    When the user searches for "T-Systems MMS"
-    Then an entry for "T-Systems Multimedia Solutions" is shown
-
-  Scenario Outline: search many things
-    When the user searches for "<searchterm>"
-    Then an entry for "<searchresult>" is shown
-
-    Examples:
-      | searchterm | searchresult                                         |
-      | Wikipedia  | Wikipedia, die freie Enzyklopädie                    |
-      | tagesschau | Tagesschau                                           |
-      | heise      | heise online - IT-News, Nachrichten und Hintergründe |
+#  Scenario: search something on google
+#    When the user searches for "T-Systems MMS"
+#    Then an entry for "T-Systems Multimedia Solutions" is shown
+#
+#  Scenario Outline: search many things
+#    When the user searches for "<searchterm>"
+#    Then an entry for "<searchresult>" is shown
+#
+#    Examples:
+#      | searchterm | searchresult                                         |
+#      | Wikipedia  | Wikipedia, die freie Enzyklopädie                    |
+#      | tagesschau | Tagesschau                                           |
+#      | heise      | heise online - IT-News, Nachrichten und Hintergründe |

--- a/cucumber-test/src/test/resources/features/GoogleSearch.feature
+++ b/cucumber-test/src/test/resources/features/GoogleSearch.feature
@@ -1,0 +1,15 @@
+Feature: google search
+
+  Scenario: search something on google
+    When the user searches for "T-Systems MMS"
+    Then an entry for "T-Systems Multimedia Solutions" is shown
+
+  Scenario Outline: search many things
+    When the user searches for "<searchterm>"
+    Then an entry for "<searchresult>" is shown
+
+    Examples:
+      | searchterm | searchresult                                         |
+      | Wikipedia  | Wikipedia, die freie Enzyklopädie                    |
+      | tagesschau | Tagesschau                                           |
+      | heise      | heise online - IT-News, Nachrichten und Hintergründe |

--- a/cucumber-test/src/test/resources/test.properties
+++ b/cucumber-test/src/test/resources/test.properties
@@ -1,0 +1,4 @@
+tt.browser=chrome
+tt.selenium.server.host=localhost
+
+tt.baseurl=http://google.com

--- a/qc-restclient/src/main/java/eu/tsystems/mms/tic/testframework/qcrest/wrapper/TestRun.java
+++ b/qc-restclient/src/main/java/eu/tsystems/mms/tic/testframework/qcrest/wrapper/TestRun.java
@@ -468,6 +468,15 @@ public class TestRun extends AbstractEntity implements Loggable {
     }
 
     /**
+     * Sets the value of the comment property.
+     *
+     * @param value
+     */
+    public void setComment(final String value){
+        setFieldValue("comments", value);
+    }
+
+    /**
      * Sets the value of the user field.
      *
      * @param value allowed object is {@link String }

--- a/qc-restclient/src/test/java/eu/tsystems/mms/tic/testframework/qcrest/test/client/AbstractTest.java
+++ b/qc-restclient/src/test/java/eu/tsystems/mms/tic/testframework/qcrest/test/client/AbstractTest.java
@@ -39,7 +39,6 @@ import org.testng.annotations.AfterSuite;
  */
 public abstract class AbstractTest extends TesterraTest implements Loggable {
     /** The test folders path. **/
-//    protected static final String TESTSET_PATH = "Root\\Xeta\\QC WebServiceClient";
     protected static final String TESTSET_PATH = "Root\\Testerra\\QCRestClient";
     /** Name of TestSet. */
     protected static final String TESTSET = "TestSetUnderTest";
@@ -55,7 +54,8 @@ public abstract class AbstractTest extends TesterraTest implements Loggable {
      */
     @AfterSuite
     public void cleanUp() throws Exception {
-        cleanUpRuns();
+        // Deactivated to keep test results in QC
+        // cleanUpRuns();
         RestConnector.getInstance().logout();
     }
 

--- a/qc-restclient/src/test/java/eu/tsystems/mms/tic/testframework/qcrest/test/client/RunClientTest.java
+++ b/qc-restclient/src/test/java/eu/tsystems/mms/tic/testframework/qcrest/test/client/RunClientTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import eu.tsystems.mms.tic.testframework.report.model.steps.TestStep;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,15 +78,21 @@ public class RunClientTest extends AbstractTest {
      * @return A newly created TestRunWr.
      */
     private TestRun createTestRun(boolean passed) {
-        final TestRun testRunWr = new TestRun();
-        testRunWr.setName("QCRestClient TestRun");
-        testRunWr.setStatus(passed ? "Passed" : "Failed");
-        testRunWr.setExecutionTime(new SimpleDateFormat("HH:mm:ss").format(new Date(System.currentTimeMillis())));
+
+        final Date date = new Date(System.currentTimeMillis());
+        SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
+
+        final TestRun testRun = new TestRun();
+        testRun.setName("QCRestClient TestRun");
+        testRun.setStatus(passed ? "Passed" : "Failed");
+        testRun.setExecutionTime(sdf.format(date));
+        sdf = new SimpleDateFormat("yyyy-MM-dd");
+        testRun.setExecutionDate(sdf.format(date));
         final Random r = new Random();
-        testRunWr.setDuration(r.nextInt(100));
-        testRunWr.setHost("somepc");
-        testRunWr.setOsName("Windows 7");
-        return testRunWr;
+        testRun.setDuration(r.nextInt(100));
+        testRun.setHost("somepc");
+//        testRun.setOsName("Windows 7");
+        return testRun;
     }
 
     /**
@@ -147,10 +154,9 @@ public class RunClientTest extends AbstractTest {
      */
     @Test
     public void testAddTestRun() throws Exception {
-        LOG.info("Test addTestRun");
-
+        TestStep.begin("Prepare run and testset");
         final TestSetTest tsTest = QcRestClient.getTestSetTest(TEST, TESTSET, TESTSET_PATH);
-        final TestRun testRun = createTestRun(false);
+        final TestRun testRun = createTestRun(true);
         final List<Attachment> lAttachmentsList = new ArrayList<Attachment>();
 
         final Attachment attach1 = new Attachment();
@@ -166,6 +172,8 @@ public class RunClientTest extends AbstractTest {
         lAttachmentsList.add(attach2);
 
         testRun.addAttachments(lAttachmentsList);
+
+        TestStep.begin("Create new run");
         int runId = 0;
         runId = QcRestClient.addTestRunToTestSet(tsTest, testRun);
         Assert.assertNotEquals(runId, 0);

--- a/qc-restclient/src/test/java/eu/tsystems/mms/tic/testframework/qcrest/test/client/RunClientTest.java
+++ b/qc-restclient/src/test/java/eu/tsystems/mms/tic/testframework/qcrest/test/client/RunClientTest.java
@@ -91,7 +91,7 @@ public class RunClientTest extends AbstractTest {
         final Random r = new Random();
         testRun.setDuration(r.nextInt(100));
         testRun.setHost("somepc");
-//        testRun.setOsName("Windows 7");
+        testRun.setOsName("Windows 7");
         return testRun;
     }
 

--- a/qc11-connector/build.gradle
+++ b/qc11-connector/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
     implementation project(':qc-restclient')
 
-
     compileOnly 'io.testerra:core:' + testerraCompileVersion
-
+    // Needed for sync of cucumber scenarios
+    implementation 'io.cucumber:cucumber-testng:' + cucumberVersion
 
     testImplementation 'io.testerra:driver-ui-desktop:' + testerraTestVersion
     testImplementation 'io.testerra:report-ng:' + testerraTestVersion

--- a/qc11-connector/build.gradle
+++ b/qc11-connector/build.gradle
@@ -1,12 +1,14 @@
 dependencies {
     implementation project(':qc-restclient')
 
+
     compileOnly 'io.testerra:core:' + testerraCompileVersion
-//    compileOnly 'io.testerra:surefire-connector:' + testerraCompileVersion
+
 
     testImplementation 'io.testerra:driver-ui-desktop:' + testerraTestVersion
-//    testImplementation 'io.testerra:surefire-connector:' + testerraTestVersion
     testImplementation 'io.testerra:report-ng:' + testerraTestVersion
+
+
 }
 
 task testQCConn(type: Test) {

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/annotation/QCPathUtil.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/annotation/QCPathUtil.java
@@ -22,7 +22,6 @@
 package eu.tsystems.mms.tic.testframework.qcconnector.annotation;
 
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
@@ -53,7 +52,6 @@ public final class QCPathUtil {
      * Liefert den QCTestsetPath zum Testng Result.
      *
      * @param result Testng result.
-     *
      * @return TestsetPath.
      */
     public static String getQCTestsetForTestNGResult(final ITestResult result) {
@@ -68,10 +66,9 @@ public final class QCPathUtil {
      * it is stored into the info container and returned. If information is already stored in the container, this value
      * is returned (also null).
      *
-     * @param clazz  Class to check.
+     * @param clazz Class to check.
      * @param method Method to check.
      * @param result result containing testParameters
-     *
      * @return any value, also null
      */
     public static String getQCTestsetPath(final Class<?> clazz, final Method method, final ITestResult result) {
@@ -98,10 +95,9 @@ public final class QCPathUtil {
     /**
      * Checks a method for a QCTestset annotation. Returns the test path. Stores the test path into the container.
      *
-     * @param clazz  .
+     * @param clazz .
      * @param method .
      * @param result .
-     *
      * @return .
      */
     private static String checkForQCTestsetInfo(Class<?> clazz, Method method, ITestResult result) {

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/annotation/QCTestname.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/annotation/QCTestname.java
@@ -1,0 +1,47 @@
+/*
+ * Testerra
+ *
+ * (C) 2020, Peter Lehmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package eu.tsystems.mms.tic.testframework.qcconnector.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that indicates to which QualityCenter Test test results should be synchronized.
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface QCTestname {
+
+    /**
+     * The name of the QC testsettest. To make the path dynamic you can use systemproperties:
+     * test_xyz_{systemproperty1}
+     *
+     * @return annotation value
+     */
+    String value() default "";
+
+    int testId() default 0;
+
+    int instanceCount() default 1;
+}

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/annotation/QCTestset.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/annotation/QCTestset.java
@@ -1,0 +1,45 @@
+/*
+ * Testerra
+ *
+ * (C) 2020, Peter Lehmann, T-Systems Multimedia Solutions GmbH, Deutsche Telekom AG
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package eu.tsystems.mms.tic.testframework.qcconnector.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * Annotation that indicates to which QualityCenter TestSet test results should be synchronized.
+ *
+ * @author mrgi, pele
+ */
+@Target({METHOD, TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface QCTestset {
+
+    /**
+     * The path to QC testset. To make the path dynamic you can use systemproperties:
+     * //Root//Release_{systemproperty1}//MyPath
+     */
+    String value() default "";
+}

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterResultSynchronizer.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterResultSynchronizer.java
@@ -18,7 +18,6 @@ import org.testng.ITestResult;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -93,17 +92,13 @@ public class QualityCenterResultSynchronizer implements TestStatusUpdateEvent.Li
         try {
             int runId = 0;
             ITestResult result = methodContext.getTestNgResult().get();
-            final Class<?> clazz = result.getTestClass().getRealClass();
-            final Method method = result.getMethod().getConstructorOrMethod().getMethod();
 
             // do not synchronize non-test methods
             if (!result.getMethod().isTest()) {
                 return;
             }
 
-//            final String methodName = result.getMethod().getMethodName();
-            final String methodName = methodContext.getName();
-            runId = QualityCenterSyncUtils.syncWithSyncType3(clazz, method, methodName, run, result);
+            runId = QualityCenterSyncUtils.syncResult(methodContext, run);
 
             if (runId > 0) {
                 // Save the runId as a result Attribute.

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterResultSynchronizer.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterResultSynchronizer.java
@@ -101,7 +101,8 @@ public class QualityCenterResultSynchronizer implements TestStatusUpdateEvent.Li
                 return;
             }
 
-            final String methodName = result.getMethod().getMethodName();
+//            final String methodName = result.getMethod().getMethodName();
+            final String methodName = methodContext.getName();
             runId = QualityCenterSyncUtils.syncWithSyncType3(clazz, method, methodName, run, result);
 
             if (runId > 0) {

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterResultSynchronizer.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterResultSynchronizer.java
@@ -134,6 +134,7 @@ public class QualityCenterResultSynchronizer implements TestStatusUpdateEvent.Li
         sdf = new SimpleDateFormat("yyyy-MM-dd");
         testRun.setExecutionDate(sdf.format(date));
         testRun.setStatus(qcTestStatus);
+        testRun.setDuration(QualityCenterSyncUtils.calculateTestDurationInSeconds(methodContext));
 
         QualityCenterSyncUtils.addQCUserFields(testRun);
 

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
@@ -236,18 +236,10 @@ public final class QualityCenterSyncUtils {
             try {
 
                 // Find out QC test
-//                final String qcTestNameAnnotation = getTestnameFromAnnotation(method);
-//                final boolean isInstanceCountAnnotation = isInstanceCountAnnotationPresent(method);
-
                 Optional<QCTestname> qcTestnameAnnotation = getQcTestnameAnnotation(method);
                 final String qcTestNameFromScenario = getCucumberTagFromResult(result, "qctestname");
                 String qcTestIdFromScenario = getCucumberTagFromResult(result, "qctestid");
 
-//                String qcTestName = qcTestNameAnnotation != null ? qcTestNameAnnotation
-//                        : (qcTestNameFromScenario != null ? qcTestNameFromScenario : methodName);
-
-//                LOGGER.info("Looking up TestSetTest " + testSetPath + " - " + qcTestName + "\nfor Test: " +
-//                        result.getTestClass().getRealClass().getSimpleName() + "#" + result.getName());
                 TestSet testSet = QcRestClient.getTestSet(testSetName, testSetFolder);
                 if (testSet != null) {
                     // Use a cache to prevent QC calls for tests of a testset

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Scanner;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -240,6 +241,7 @@ public final class QualityCenterSyncUtils {
 
                 Optional<QCTestname> qcTestnameAnnotation = getQcTestnameAnnotation(method);
                 final String qcTestNameFromScenario = getCucumberTagFromResult(result, "qctestname");
+                String qcTestIdFromScenario = getCucumberTagFromResult(result, "qctestid");
 
 //                String qcTestName = qcTestNameAnnotation != null ? qcTestNameAnnotation
 //                        : (qcTestNameFromScenario != null ? qcTestNameFromScenario : methodName);
@@ -270,6 +272,7 @@ public final class QualityCenterSyncUtils {
                             qcTestSetTestName = String.format("%s [%s]", qcTestnameAnnotation.get().value(), qcTestInstance);
                         } else {
                             qcTestSetTestName = String.format("%s [%s]", qcTestNameFromScenario != null ? qcTestNameFromScenario : methodName, qcTestInstance);
+                            qcTestId = qcTestIdFromScenario != null ? new Scanner(qcTestIdFromScenario).useDelimiter("\\D").nextInt() : 0;
                         }
 
                         if (
@@ -277,22 +280,8 @@ public final class QualityCenterSyncUtils {
                                         test.getTestInstanceName().equals(qcTestSetTestName)
                         ) {
                             matchingTest = test;
-//                            break;
+                            break;
                         }
-
-//                        if (isInstanceCountAnnotation) {
-//                            qcTestSetTestName = test.getTestInstanceName();
-//                            qcTestId = test.getTestId();
-//                        } else {
-//                            QcTest qcTest = test.getTest();
-//                            qcTestSetTestName = qcTest.getName();
-//                            qcTestId = test.getTestId();
-//                        }
-//
-//                        if (qcTestSetTestName.equalsIgnoreCase(qcTestSetTestName)) {
-//                            matchingTest = test;
-//                            break;
-//                        }
                     }
 
                     if (matchingTest == null) {
@@ -308,13 +297,7 @@ public final class QualityCenterSyncUtils {
                         }
                     }
                     if (matchingTest == null) {
-                        final StringBuilder error = new StringBuilder();
-                        error.append("No method ");
-                        error.append(methodName);
-                        error.append(" found in Testset ");
-                        error.append(testSetPath);
-                        error.append(". Could not synchronize with QC! ");
-                        LOGGER.error(error.toString());
+                        LOGGER.error("No method {} found in Testset {}. Could not synchronize with QC!", methodName, testSetPath);
                     }
                 } else {
                     String errorMsg = ErrorMessages.wrongQCTestSetAnnotation(testSetPath, clazz.getName());
@@ -342,61 +325,6 @@ public final class QualityCenterSyncUtils {
         }
         return matchingTest;
     }
-
-    // TODO: remove
-//    /**
-//     * Read QCTestname annotation from test method.
-//     *
-//     * @return Found value or null.
-//     */
-//    private static String getTestnameFromAnnotation(Method method) {
-//
-//        String methodName = method.getName();
-//        String testname = null;
-//        int instanceCount;
-//
-//        // Get the annotation.
-//        final QCTestname qcTestname = getQcTestnameAnnotation(method);
-//
-//        // Get the test path info.
-//        if (qcTestname != null) {
-//            if (StringUtils.isNotEmpty(qcTestname.value())) {
-//
-//                testname = qcTestname.value().trim();
-//                instanceCount = qcTestname.instanceCount(); // default = 0 --> No instance count necessary
-//
-//                if (instanceCount > 0) {
-//                    LOGGER.debug("Instance count set on QCTestname annotation.");
-//                    testname = String.format("%s [%s]", testname, instanceCount);
-//                }
-//
-//                LOGGER.debug(String.format("Found QCTestname annotation with value %s for method %s", testname, methodName));
-//            }
-//        }
-//        return testname;
-//    }
-
-//    private static boolean isInstanceCountAnnotationPresent(final Method method) {
-//
-//        final QCTestname qcTestnameAnnotation = getQcTestnameAnnotation(method);
-//
-//        if (qcTestnameAnnotation != null) {
-//            return qcTestnameAnnotation.instanceCount() > 0;
-//        }
-//
-//        return false;
-//    }
-
-//    private static QCTestname getQcTestnameAnnotation(final Method method) {
-//
-//        QCTestname annotation = null;
-//
-//        if (method.isAnnotationPresent(QCTestname.class)) {
-//            annotation = method.getAnnotation(QCTestname.class);
-//        }
-//
-//        return annotation;
-//    }
 
     private static Optional<QCTestname> getQcTestnameAnnotation(final Method method) {
 

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
@@ -227,14 +227,14 @@ public final class QualityCenterSyncUtils {
 //                String qcTestName = methodName;
                 final String qcTestNameAnnotation = getTestnameFromAnnotation(method);
                 final boolean isInstanceCountAnnotation = isInstanceCountAnnotationPresent(method);
-                final String qcTestNameFromSzenario = getTestnameFromScenario(result);
+                final String qcTestNameFromScenario = getTestnameFromScenario(result);
 
 //                if (qcTestNameAnnotation != null) {
 //                    qcTestName = qcTestNameAnnotation;
 //                }
 
                 String qcTestName = qcTestNameAnnotation != null ? qcTestNameAnnotation
-                        : (qcTestNameFromSzenario != null ? qcTestNameFromSzenario : methodName);
+                        : (qcTestNameFromScenario != null ? qcTestNameFromScenario : methodName);
 
                 LOGGER.info("Looking up TestSetTest " + testSetPath + " - " + qcTestName + "\nfor Test: " +
                         result.getTestClass().getRealClass().getSimpleName() + "#" + result.getName());

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
@@ -261,17 +261,20 @@ public final class QualityCenterSyncUtils {
 
                     for (final TestSetTest test : testSetTests) {
 
-                        // Determine valid name. Use instance name instead of test method name whne instance count is present on annotation.
+                        // Determine valid name. Use instance name instead of test method name when instance count is present on annotation.
                         String qcTestMethodName;
+                        int qcTestMethodId;
 
                         if (isInstanceCountAnnotation) {
                             qcTestMethodName = test.getTestInstanceName();
+                            qcTestMethodId = test.getTestId();
                         } else {
                             QcTest qcTest = test.getTest();
                             qcTestMethodName = qcTest.getName();
+                            qcTestMethodId = test.getTestId();
                         }
 
-                        if (qcTestMethodName.equalsIgnoreCase(qcTestName)) {
+                        if (qcTestMethodName.equalsIgnoreCase(qcTestName) ) {
                             matchingTest = test;
                             break;
                         }

--- a/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
+++ b/qc11-connector/src/main/java/eu/tsystems/mms/tic/testframework/qcconnector/synchronize/QualityCenterSyncUtils.java
@@ -51,6 +51,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -536,6 +537,11 @@ public final class QualityCenterSyncUtils {
             }
         }
         return stringToCut;
+    }
+
+    public static int calculateTestDurationInSeconds(MethodContext context) {
+        Duration between = Duration.between(context.getStartTime().toInstant(), context.getEndTime().toInstant());
+        return Double.valueOf(between.toMillis() / 1000.0).intValue();
     }
 
     /**

--- a/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
+++ b/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
@@ -1,6 +1,7 @@
 package eu.tsystems.mms.tic.testframework.qc11connector.test;
 
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
+import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestname;
 import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;
 import eu.tsystems.mms.tic.testframework.utils.UITestUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
@@ -23,6 +24,7 @@ public class QcStatusSyncTest extends TesterraTest {
         Assert.assertEquals(1,2);
     }
 
+    @QCTestname("T02_QcSyncResultPassed")
     @Test
     public void testT02_QcSyncResultPassed() {
         Assert.assertEquals(1,1);

--- a/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
+++ b/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
@@ -1,8 +1,8 @@
 package eu.tsystems.mms.tic.testframework.qc11connector.test;
 
+import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestname;
+import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestset;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestname;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;
 import eu.tsystems.mms.tic.testframework.utils.UITestUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
 import org.testng.Assert;
@@ -24,9 +24,15 @@ public class QcStatusSyncTest extends TesterraTest {
         Assert.assertEquals(1,2);
     }
 
-    @QCTestname("T02_QcSyncResultPassed")
+    @QCTestname(value = "T02_QcSyncResultPassed")
     @Test
     public void testT02_QcSyncResultPassed() {
+        Assert.assertEquals(1,1);
+    }
+
+    @QCTestname(value = "T02_QcSyncResultPassed", instanceCount = 2)
+    @Test
+    public void testT02a_QcSyncResultPassed() {
         Assert.assertEquals(1,1);
     }
 
@@ -42,6 +48,11 @@ public class QcStatusSyncTest extends TesterraTest {
     @QCTestname("T04 QcSyncResult Passed Spaces")
     @Test
     public void testT04_QcSyncResultPassedSpaces() {
+    }
+
+    @QCTestname(testId = 2264, instanceCount = 2)
+    @Test
+    public void testT04a_QcSyncResultPassedSpacesPerId() {
     }
 
 

--- a/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
+++ b/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
@@ -36,5 +36,13 @@ public class QcStatusSyncTest extends TesterraTest {
 
     }
 
+    /**
+     * Test method names in Quality Center can contain spaces.
+     */
+    @QCTestname("T04 QcSyncResult Passed Spaces")
+    @Test
+    public void testT04_QcSyncResultPassedSpaces() {
+    }
+
 
 }

--- a/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
+++ b/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
@@ -3,6 +3,7 @@ package eu.tsystems.mms.tic.testframework.qc11connector.test;
 import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestname;
 import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestset;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
+import eu.tsystems.mms.tic.testframework.utils.TimerUtils;
 import eu.tsystems.mms.tic.testframework.utils.UITestUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
 import org.testng.Assert;
@@ -27,6 +28,7 @@ public class QcStatusSyncTest extends TesterraTest {
     @QCTestname(value = "T02_QcSyncResultPassed")
     @Test
     public void testT02_QcSyncResultPassed() {
+        TimerUtils.sleep(2_000, "Waiter to get test duration.");
         Assert.assertEquals(1,1);
     }
 

--- a/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
+++ b/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/test/QcStatusSyncTest.java
@@ -15,6 +15,7 @@ import org.testng.annotations.Test;
 @QCTestset("Root\\Testerra\\QCSyncResultTests\\QcSyncResultTests")
 public class QcStatusSyncTest extends TesterraTest {
 
+    // It results in 2 screenshots are synced to QC
     @Test
     public void testT01_QcSyncResultFailed() {
         WebDriverManager.getWebDriver();

--- a/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/testsundertest/AttachmentUploadTests.java
+++ b/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/testsundertest/AttachmentUploadTests.java
@@ -22,8 +22,8 @@
 package eu.tsystems.mms.tic.testframework.qc11connector.testsundertest;
 
 import eu.tsystems.mms.tic.testframework.qc11connector.constants.QCConstants;
+import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestset;
 import eu.tsystems.mms.tic.testframework.qcrest.constants.QCProperties;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;
 import eu.tsystems.mms.tic.testframework.utils.UITestUtils;
 import eu.tsystems.mms.tic.testframework.webdrivermanager.WebDriverManager;
 import org.openqa.selenium.WebDriver;

--- a/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/testsundertest/CorrectClassAnnotationTest.java
+++ b/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/testsundertest/CorrectClassAnnotationTest.java
@@ -22,9 +22,9 @@
 package eu.tsystems.mms.tic.testframework.qc11connector.testsundertest;
 
 import eu.tsystems.mms.tic.testframework.qc11connector.constants.QCConstants;
+import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestname;
+import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestset;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestname;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/testsundertest/NoClassAnnotationTest.java
+++ b/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/testsundertest/NoClassAnnotationTest.java
@@ -22,9 +22,9 @@
 package eu.tsystems.mms.tic.testframework.qc11connector.testsundertest;
 
 import eu.tsystems.mms.tic.testframework.qc11connector.constants.QCConstants;
+import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestname;
+import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestset;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestname;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/testsundertest/WrongClassAnnotationTest.java
+++ b/qc11-connector/src/test/java/eu/tsystems/mms/tic/testframework/qc11connector/testsundertest/WrongClassAnnotationTest.java
@@ -22,8 +22,7 @@
 package eu.tsystems.mms.tic.testframework.qc11connector.testsundertest;
 
 import eu.tsystems.mms.tic.testframework.qc11connector.constants.QCConstants;
-import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
-import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;
+import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestset;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'testerra-hpqc-connector'
 include 'qc-restclient'
 include 'qc11-connector'
+include 'cucumber-test'
 


### PR DESCRIPTION
# Description

- The annotation `@QCTestname` for Java methods supportes the attribute `testId`. Instead of using the the name you can use the QC test id:
    ````java
    @QCTestname(testId = 2264)
    @Test
    public void testT04a_QcSyncResultPassedSpacesPerId() {
    }
    ````

* Syncing of Cucumber scenarios is supported now: 
  * Use the tag `@QCTestname("QC-Testname")` _or_
  * use the tag `@QCTestId("123")`
  * See an example in the subproject `cucumber-test` or in README.

## Breaking change

The annotation classes `@QCTestset` and `@QCTestname` are now part of QC connector. The classes of Testerra will be ignored! 

For migration please update your imports:

````java
// with old version
import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestname;
import eu.tsystems.mms.tic.testframework.testmanagement.annotation.QCTestset;

// change it to
import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestname;
import eu.tsystems.mms.tic.testframework.qcconnector.annotation.QCTestset;
````

Fixes #5 

## What else?
* Added duration to test runs

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
